### PR TITLE
Fix naming clash with RuneLite's slayer plugin

### DIFF
--- a/plugins/slayer-assistant
+++ b/plugins/slayer-assistant
@@ -1,2 +1,2 @@
 repository=https://github.com/LeeOkeefe/slayer-assistant-plugin.git
-commit=49fd7896704421f34388c0165ffb67f574aff1e9
+commit=7a24e969347a4be178e67615bbd07b5687c9308f


### PR DESCRIPTION
The plugin class/file name for Slayer Assistant was 'SlayerPlugin', which is also the same name for the built-in Slayer plugin from RuneLite.

The same naming was causing both plugins to be enabled/disabled, so the class/file for slayer assistant has been renamed to SlayerAssistantPlugin to avoid the naming clash.